### PR TITLE
Expose WS events

### DIFF
--- a/examples/test-blade.py
+++ b/examples/test-blade.py
@@ -25,11 +25,29 @@ async def ready(client):
   # else:
   #   print('Outbound call failed or not answered')
 
+def socket_open():
+  print('socket_open')
+
+def socket_error(error):
+  print('socket_error')
+  print(error)
+
+def socket_message(msg):
+  print('socket_message')
+  print(msg)
+
+def socket_close():
+  print('socket_close')
+
 def main():
   project = os.getenv('PROJECT', '')
   token = os.getenv('TOKEN', '')
   client = Client(project=project, token=token)
   client.on('ready', ready)
+  client.on('signalwire.socket.open', socket_open)
+  client.on('signalwire.socket.error', socket_error)
+  client.on('signalwire.socket.message', socket_message)
+  client.on('signalwire.socket.close', socket_close)
   client.connect()
 
 main()

--- a/signalwire/blade/handler.py
+++ b/signalwire/blade/handler.py
@@ -3,29 +3,29 @@ from .helpers import safe_invoke_callback
 GLOBAL = 'GLOBAL'
 _queue = {}
 
-def register(event, callback, unique_id = GLOBAL):
+def register(*, event, callback, suffix=GLOBAL):
   global _queue
 
-  event = build_event_name(event, unique_id)
+  event = build_event_name(event, suffix)
   if event not in _queue:
     _queue[event] = []
   _queue[event].append(callback)
 
-def register_once(event, callback, unique_id = GLOBAL):
+def register_once(*, event, callback, suffix=GLOBAL):
   global _queue
 
   def cb(*args):
-    unregister(event, cb, unique_id)
+    unregister(event=event, callback=cb, suffix=suffix)
     callback(*args)
 
-  register(event, cb, unique_id)
+  register(event=event, callback=cb, suffix=suffix)
 
-def unregister(event, callback = None, unique_id = GLOBAL):
+def unregister(*, event, callback=None, suffix=GLOBAL):
   global _queue
 
-  if is_queued(event, unique_id) is False:
+  if is_queued(event, suffix) is False:
     return False
-  event = build_event_name(event, unique_id)
+  event = build_event_name(event, suffix)
   if callback is None:
     _queue[event] = []
   else:
@@ -38,28 +38,28 @@ def unregister(event, callback = None, unique_id = GLOBAL):
 
   return True
 
-def trigger(event, data, unique_id = GLOBAL):
+def trigger(event, *args, suffix=GLOBAL, **kwargs):
   global _queue
 
-  if is_queued(event, unique_id) is False:
+  if is_queued(event, suffix) is False:
     return False
-  event = build_event_name(event, unique_id)
+  event = build_event_name(event, suffix)
   for callback in _queue[event]:
-    safe_invoke_callback(callback, data)
+    safe_invoke_callback(callback, *args, **kwargs)
   return True
 
-def is_queued(event, unique_id = GLOBAL):
+def is_queued(event, suffix=GLOBAL):
   global _queue
 
-  event = build_event_name(event, unique_id)
+  event = build_event_name(event, suffix)
   return event in _queue and len(_queue[event]) > 0
 
-def queue_size(event, unique_id = GLOBAL):
+def queue_size(event, suffix=GLOBAL):
   global _queue
 
-  if is_queued(event, unique_id) is False:
+  if is_queued(event, suffix) is False:
     return 0
-  event = build_event_name(event, unique_id)
+  event = build_event_name(event, suffix)
   return len(_queue[event])
 
 def clear():
@@ -67,5 +67,5 @@ def clear():
 
   _queue = {}
 
-def build_event_name(event, unique_id):
-  return "{0}|{1}".format(event.strip(), unique_id.strip())
+def build_event_name(event, suffix):
+  return "{0}|{1}".format(event.strip(), suffix.strip())

--- a/signalwire/relay/__init__.py
+++ b/signalwire/relay/__init__.py
@@ -23,6 +23,6 @@ class BaseRelay(ABC):
       logging.info(f'Trying to receive contexts: {contexts}')
       await receive_contexts(self.client, contexts)
       for context in contexts:
-        register(self.client.protocol, handler, self.ctx_receive_unique(context))
+        register(event=self.client.protocol, callback=handler, suffix=self.ctx_receive_unique(context))
     except Exception as error:
       logging.error('receive error: {0}'.format(str(error)))

--- a/signalwire/relay/calling/__init__.py
+++ b/signalwire/relay/calling/__init__.py
@@ -68,7 +68,7 @@ class Calling(BaseRelay):
         call.id = params['call_id']
         call.node_id = params['node_id']
       call._state_changed(params)
-      trigger(Notification.STATE, params, call.tag) # Notify components listening on State and Tag
+      trigger(Notification.STATE, params, suffix=call.tag) # Notify components listening on State and Tag
     elif 'call_id' in params and 'peer' in params:
       call = Call(calling=self, **params)
     else:
@@ -76,4 +76,4 @@ class Calling(BaseRelay):
 
   def _on_receive(self, params):
     call = Call(calling=self, **params)
-    trigger(self.client.protocol, call, self.ctx_receive_unique(call.context))
+    trigger(self.client.protocol, call, suffix=self.ctx_receive_unique(call.context))

--- a/signalwire/relay/calling/call.py
+++ b/signalwire/relay/calling/call.py
@@ -72,7 +72,7 @@ class Call:
     self.state = params['call_state']
     if self.state == CallState.ENDED:
       check_id = self.id if self.id else self.tag
-      trigger(check_id, params, CallState.ENDED) # terminate components
+      trigger(check_id, params, suffix=CallState.ENDED) # terminate components
       end_reason = params.get('end_reason', '')
       self.failed = end_reason == DisconnectReason.ERROR
       self.busy = end_reason == DisconnectReason.BUSY

--- a/signalwire/relay/calling/components/__init__.py
+++ b/signalwire/relay/calling/components/__init__.py
@@ -35,14 +35,14 @@ class BaseComponent(ABC):
     pass
 
   def register(self):
-    register(self.event_type, self.notification_handler, self.control_id)
+    register(event=self.event_type, callback=self.notification_handler, suffix=self.control_id)
     check_id = self.call.id if self.call.id else self.call.tag
-    register(check_id, self.terminate, CallState.ENDED)
+    register(event=check_id, callback=self.terminate, suffix=CallState.ENDED)
 
   def unregister(self):
-    unregister(self.event_type, self.notification_handler, self.control_id)
-    unregister(self.call.id, self.terminate, CallState.ENDED)
-    unregister(self.call.tag, self.terminate, CallState.ENDED)
+    unregister(event=self.event_type, callback=self.notification_handler, suffix=self.control_id)
+    unregister(event=self.call.id, callback=self.terminate, suffix=CallState.ENDED)
+    unregister(event=self.call.tag, callback=self.terminate, suffix=CallState.ENDED)
 
   async def execute(self):
     if self.call.ended == True:

--- a/signalwire/relay/client.py
+++ b/signalwire/relay/client.py
@@ -82,11 +82,11 @@ class Client:
     self.loop.stop()
 
   def on(self, event, callback):
-    register(event, callback, self.uuid)
+    register(event=event, callback=callback, suffix=self.uuid)
     return self
 
   def off(self, event, callback=None):
-    unregister(event, callback, self.uuid)
+    unregister(event=event, callback=callback, suffix=self.uuid)
     return self
 
   async def cancel_pending_tasks(self):
@@ -106,7 +106,8 @@ class Client:
       self.session_id = result['sessionid']
       self.signature = result['authorization']['signature']
       self.protocol = await setup_protocol(self)
-      trigger('ready', self, self.uuid)
+      logging.info('Client connected!')
+      trigger('ready', self, suffix=self.uuid)
     except Exception as error:
       logging.error('Client setup error: {0}'.format(str(error)))
       await self.connection.close()

--- a/signalwire/relay/constants.py
+++ b/signalwire/relay/constants.py
@@ -1,2 +1,9 @@
 class Constants:
   HOST = 'relay.signalwire.com'
+  READY = 'ready'
+
+class WebSocketEvents:
+  OPEN = 'signalwire.socket.open'
+  CLOSE = 'signalwire.socket.close'
+  MESSAGE = 'signalwire.socket.message'
+  ERROR = 'signalwire.socket.error'

--- a/signalwire/relay/tasking/__init__.py
+++ b/signalwire/relay/tasking/__init__.py
@@ -11,4 +11,4 @@ class Tasking(BaseRelay):
   def notification_handler(self, notification):
     context = notification['context']
     logging.info(f'Receive task in context: {context}')
-    trigger(self.client.protocol, notification['message'], self.ctx_receive_unique(context))
+    trigger(self.client.protocol, notification['message'], suffix=self.ctx_receive_unique(context))

--- a/signalwire/tests/blade/test_handler.py
+++ b/signalwire/tests/blade/test_handler.py
@@ -7,17 +7,17 @@ class TestBladeMessages(TestCase):
     clear()
 
   def test_register(self):
-    register('event_name', lambda x: print(x))
-    register('event_name', lambda x: print(x))
-    register('event_name', lambda x: print(x))
+    register(event='event_name', callback=lambda x: print(x))
+    register(event='event_name', callback=lambda x: print(x))
+    register(event='event_name', callback=lambda x: print(x))
 
     self.assertTrue(is_queued('event_name'))
     self.assertEqual(queue_size('event_name'), 3)
 
   def test_register_with_unique_id(self):
-    register('event_name', lambda x: print(x), 'xxx')
-    register('event_name', lambda x: print(x), 'yyy')
-    register('event_name', lambda x: print(x), 'zzz')
+    register(event='event_name', callback=lambda x: print(x), suffix='xxx')
+    register(event='event_name', callback=lambda x: print(x), suffix='yyy')
+    register(event='event_name', callback=lambda x: print(x), suffix='zzz')
 
     self.assertFalse(is_queued('event_name'))
     self.assertEqual(queue_size('event_name', 'xxx'), 1)
@@ -25,7 +25,7 @@ class TestBladeMessages(TestCase):
 
   def test_register_once(self):
     mock = Mock()
-    register_once('event_name', mock)
+    register_once(event='event_name', callback=mock)
     self.assertEqual(queue_size('event_name'), 1)
     trigger('event_name', 'custom data')
     self.assertEqual(queue_size('event_name'), 0)
@@ -35,64 +35,64 @@ class TestBladeMessages(TestCase):
 
   def test_register_once_with_unique_id(self):
     mock = Mock()
-    register_once('event_name', mock, 'uuid')
+    register_once(event='event_name', callback=mock, suffix='uuid')
     self.assertEqual(queue_size('event_name', 'uuid'), 1)
-    trigger('event_name', 'custom data', 'uuid')
+    trigger('event_name', 'custom data', suffix='uuid')
     self.assertEqual(queue_size('event_name'), 0)
-    trigger('event_name', 'custom data', 'uuid')
-    trigger('event_name', 'custom data', 'uuid')
+    trigger('event_name', 'custom data', suffix='uuid')
+    trigger('event_name', 'custom data', suffix='uuid')
     mock.assert_called_once()
 
   def test_unregister(self):
     mock = Mock()
-    register('event_name', mock)
+    register(event='event_name', callback=mock)
     self.assertEqual(queue_size('event_name'), 1)
 
-    unregister('event_name', mock)
+    unregister(event='event_name', callback=mock)
     self.assertEqual(queue_size('event_name'), 0)
     trigger('event_name', 'custom data')
     mock.assert_not_called()
 
   def test_unregister_with_unique_id(self):
     mock = Mock()
-    register('event_name', mock, 'xxx')
+    register(event='event_name', callback=mock, suffix='xxx')
     self.assertEqual(queue_size('event_name', 'xxx'), 1)
 
-    unregister('event_name', mock, 'xxx')
+    unregister(event='event_name', callback=mock, suffix='xxx')
     self.assertEqual(queue_size('event_name', 'xxx'), 0)
     trigger('event_name', 'custom data', 'xxx')
     mock.assert_not_called()
 
   def test_unregister_without_callbak(self):
     mock = Mock()
-    register('event_name', mock)
+    register(event='event_name', callback=mock)
     self.assertEqual(queue_size('event_name'), 1)
 
-    unregister('event_name', None)
+    unregister(event='event_name')
     self.assertEqual(queue_size('event_name'), 0)
     trigger('event_name', 'custom data')
     mock.assert_not_called()
 
   def test_clear(self):
-    register('event_name', lambda x: print(x))
+    register(event='event_name', callback=lambda x: print(x))
     self.assertEqual(queue_size('event_name'), 1)
     clear()
     self.assertEqual(queue_size('event_name'), 0)
 
   def test_trigger(self):
     mock = Mock()
-    register('event_name', mock)
+    register(event='event_name', callback=mock)
     mock.assert_not_called()
     trigger('event_name', 'custom data')
     mock.assert_called_once()
 
   def test_trigger_with_unique_id(self):
     mock1 = Mock()
-    register('event_name', mock1, 'some_uuid')
+    register(event='event_name', callback=mock1, suffix='some_uuid')
     mock2 = Mock()
-    register('event_name', mock2, 'other_uuid')
+    register(event='event_name', callback=mock2, suffix='other_uuid')
     mock1.assert_not_called()
     mock2.assert_not_called()
-    trigger('event_name', 'custom data', 'some_uuid')
+    trigger('event_name', 'custom data', suffix='some_uuid')
     mock1.assert_called_once()
     mock2.assert_not_called()


### PR DESCRIPTION
This PR contains a review of the internal Handler class to use keyword arguments instead of positional. This will help in the future to use `*args` and `**kwargs` if needed.