### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,41 @@
+import os, codecs
 from setuptools import setup, find_packages
 
-setup(name='signalwire',
-      version='1.5.0',
-      description='Provides SignalWire LAML and REST functionality',
-      url='https://github.com/signalwire/signalwire-python',
-      author='SignalWire Team',
-      author_email='open.source@signalwire.com',
-      license='MIT',
-      packages=find_packages(exclude=['tests', 'tests.*']),
-      install_requires=[
-          'twilio==6.16.4',
-      ],
-      python_requires='>=3',
-      zip_safe=False)
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+def read(*file_paths):
+  """Read file data."""
+  with codecs.open(os.path.join(HERE, *file_paths), "r") as file_in:
+    return file_in.read()
+
+CLASSIFIERS = [
+  'Development Status :: 4 - Beta',
+  'Intended Audience :: Developers',
+  'Intended Audience :: Information Technology',
+  'Intended Audience :: Telecommunications Industry',
+  'License :: OSI Approved :: MIT License',
+  'Natural Language :: English',
+  'Topic :: Communications',
+  'Topic :: Software Development'
+]
+
+setup(
+  name='signalwire',
+  version='2.0.0b1',
+  description='Client library for connecting to SignalWire.',
+  long_description=read('README.md'),
+  long_description_content_type="text/markdown",
+  classifiers=CLASSIFIERS,
+  url='https://github.com/signalwire/signalwire-python',
+  author='SignalWire Team',
+  author_email='open.source@signalwire.com',
+  license='MIT',
+  packages=find_packages(exclude=['tests', 'tests.*']),
+  install_requires=[
+    'twilio==6.16.4',
+    'aiohttp',
+    'asyncio'
+  ],
+  python_requires='>=3.6',
+  zip_safe=False
+)


### PR DESCRIPTION
Please, double check with the links below to see if i missed something for the package (classifiers and beta version).
Regarding the required Python version: asyncio is in the standard library from `3.4` but the full support is from `3.6+`.

- [Beta version flag](https://www.python.org/dev/peps/pep-0440/#pre-releases)
- [Beta version flag 2](https://packaging.python.org/guides/distributing-packages-using-setuptools/#choosing-a-versioning-scheme)
- [Classifiers](https://pypi.org/classifiers/)
- [Python min version for asyncio](https://realpython.com/async-io-python/#conclusion)

