### PR TITLE
Remove previous requests when done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2020-03-10
+### Fixed
+- Delete the `_request` dict key once the request has been completed.
+
 ## [2.0.1] - 2019-12-05
 ### Fixed
 - Call prompt `media_list` parameter without nested _params_ property.

--- a/signalwire/__init__.py
+++ b/signalwire/__init__.py
@@ -1,3 +1,3 @@
 name = "signalwire"
 
-__version__ = '2.0.1'
+__version__ = '2.0.2'

--- a/signalwire/relay/client.py
+++ b/signalwire/relay/client.py
@@ -71,8 +71,9 @@ class Client:
       await self._executeQueue.put(message)
     else:
       await self.connection.send(message)
-
-    return await self._requests[message.id]
+    result = await self._requests[message.id]
+    del self._requests[message.id]
+    return result
 
   def connect(self):
     while self._reconnect:


### PR DESCRIPTION
Looking for the Blade timeout issue i found that the old requests are not removed once completed.

The client automatically reconnect in case of Timeout.