### PR TITLE
Drop asyncio requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
   install_requires=[
     'twilio==6.16.4',
     'aiohttp',
-    'asyncio'
   ],
   python_requires='>=3.6',
   zip_safe=False

--- a/signalwire/__init__.py
+++ b/signalwire/__init__.py
@@ -1,3 +1,3 @@
 name = "signalwire"
 
-__version__ = '2.0.2'
+__version__ = '2.0.3'


### PR DESCRIPTION
In fact it was added to Python 3.4. The asyncio external package is intended for Python 3.3 and older.