### PR TITLE
fix: lock aiohttp version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,6 @@ pytest-asyncio = "*"
 [packages]
 twilio = "==6.54.0"
 signalwire = {editable = true,path = "."}
-aiohttp = "*"
+aiohttp = "3.9.5"
 
 [requires]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
   packages=find_packages(exclude=['tests', 'tests.*']),
   install_requires=[
     'twilio==6.54.0',
-    'aiohttp',
+    'aiohttp==3.9.5',
   ],
   python_requires='>=3.6',
   zip_safe=False

--- a/signalwire/__init__.py
+++ b/signalwire/__init__.py
@@ -1,3 +1,3 @@
 name = "signalwire"
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'


### PR DESCRIPTION
The latest `3.11.*` aiohttp was failing with:

> RuntimeError: no running event loop

Locking it to an older version that was confirmed working (`3.9.5`) seems to fix the issue. 


refs: https://github.com/aio-libs/aiohttp/issues/8555